### PR TITLE
Update Marlin_main.cpp

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2467,8 +2467,14 @@ Sigma_Exit:
       #ifdef AUTOTEMP
         autotemp_enabled=false;
       #endif
-      if (code_seen('S')) {
-        setTargetHotend(code_value(), tmp_extruder);
+      if (code_seen('S'))
+      {
+         if (code_value() == 0.0)
+            reset_preheat_time(tmp_extruder);
+         else
+            start_preheat_time(tmp_extruder);
+
+         setTargetHotend(code_value(), tmp_extruder);
 #ifdef DUAL_X_CARRIAGE
         if (dual_x_carriage_mode == DXC_DUPLICATION_MODE && tmp_extruder == 0)
           setTargetHotend1(code_value() == 0.0 ? 0.0 : code_value() + duplicate_extruder_temp_offset);


### PR DESCRIPTION
Fix the mintemp error when pre-heating the hotend (using M109 command)
